### PR TITLE
Make use of SpawnHeightOffset for landed pads

### DIFF
--- a/Source/BuildWindow.cs
+++ b/Source/BuildWindow.cs
@@ -494,6 +494,31 @@ namespace ExLP {
 
 		void FinalizeButton ()
 		{
+            if (pad.vessel.situation == Vessel.Situations.LANDED)
+            {
+                GUILayout.BeginVertical();
+                GUILayout.Space(10.0f);
+                GUILayout.BeginHorizontal();
+                GUILayout.Box("Spawn Height Offset", Styles.white, GUILayout.Width(180), GUILayout.Height(40));
+                pad.SpawnHeightOffset = GUILayout.HorizontalSlider(pad.SpawnHeightOffset, 0.0F, 10.0F,
+                                                       Styles.slider,
+                                                       GUI.skin.horizontalSliderThumb,
+                                                       GUILayout.Width(300),
+                                                       GUILayout.Height(40));
+                pad.SpawnHeightOffset = (float)Math.Round(pad.SpawnHeightOffset, 1);
+                GUILayout.Box(pad.SpawnHeightOffset.ToString() + " meters",
+                               Styles.white, GUILayout.Width(200),
+                               GUILayout.Height(40));
+                GUILayout.FlexibleSpace();
+
+                GUILayout.EndHorizontal();
+                GUILayout.EndVertical();
+            }
+            else
+            {
+                pad.SpawnHeightOffset = 0.0f;
+            }
+			
 			if (GUILayout.Button ("Finalize Build", Styles.normal,
 								  GUILayout.ExpandWidth (true))) {
 				pad.BuildAndLaunchCraft ();


### PR DESCRIPTION
A quick addition... I had a few difficulties with the plugin when using it to build a return vehicle from a sea level base on Eve. The insane dV required to get into orbit requires a mammoth craft, and with the vehicle spawned in contact with the pad, it ends up crushing the pad when the vehicle is released. Launch stabilizers don't completely mediate the problem--super lifters will still sag once the physics has started. The fix is super easy, though... I added a bit of code to let the user choose the spawn height offset of the vehicle just before finalizing the build: anything from 0 to 10m is allowed, and only if the pad is landed. With this change a super heavy lifter can sway and sag happily a few meters above the pad without crushing it (or anything to which it's attached). One note--you may want to consider upping the maxTemp for launchpad parts--I'm using Module Manager to increase the value so my super heavy lifter won't incinerate the pad on liftoff.
