### PR TITLE
ModuleManager 2 and custom command pod support

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/EL_MM.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/EL_MM.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[ExWorkshop]]
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[ExWorkshop]]:FOR[Launchpad]
 {
 	MODULE {
 		name = ExWorkshop
@@ -10,7 +10,7 @@
 	}
 }
 
-@PART[crewCabin]
+@PART[crewCabin]:FOR[Launchpad]
 {
 	MODULE {
 		name = ExWorkshop
@@ -19,12 +19,12 @@
 	}
 }
 
-@PART[Large_Crewed_Lab]
+@PART[Large_Crewed_Lab]:FOR[Launchpad]
 {
 	MODULE {
 		name = ExWorkshop
 		// The science lab is ok (it has some specialized equipment that
-		// can help), but it's till not ideal
+		// can help), but it's still not ideal
 		ProductivityFactor = 0.6
 	}
 }


### PR DESCRIPTION
I propose moving these MM patches into the (already-existing) `FOR[Launchpad]` time slot, especially the first one. This way, players can use ModuleManager to add `ExWorkshop` to specific command pods _before_ they get overridden by the generic config. Sweeping changes to `PART[*]` should never be applied in the initial pass, just on general principle.

Also, typo.
