### PR TITLE
Create stock toolbar icon if no Blizzy's toolbar

### DIFF
--- a/Source/toolbar/Toolbar.cs
+++ b/Source/toolbar/Toolbar.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using KSP.UI.Screens;
 
 namespace ExtraplanetaryLaunchpads {
 	using Toolbar;
@@ -27,16 +28,32 @@ namespace ExtraplanetaryLaunchpads {
 	public class ExToolbar_ShipInfo : MonoBehaviour
 	{
 		private IButton ExEditorButton;
+		private static ApplicationLauncherButton appEditorButton = null;
 
 		public void Awake ()
 		{
 			if (ToolbarManager.Instance == null) {
+				if (appEditorButton == null) {
+					GameEvents.onGUIApplicationLauncherReady.Add(setupAppButton_ShipInfo);
+				}
 				return;
 			}
 			ExEditorButton = ToolbarManager.Instance.add ("ExtraplanetaryLaunchpads", "ExEditorButton");
 			ExEditorButton.TexturePath = "ExtraplanetaryLaunchpads/Textures/icon_button";
 			ExEditorButton.ToolTip = "EL Build Resources Display";
 			ExEditorButton.OnClick += (e) => ExShipInfo.ToggleGUI ();
+		}
+
+		public void setupAppButton_ShipInfo() {
+			if (appEditorButton == null) {
+				if (ApplicationLauncher.Ready) {
+					appEditorButton = ApplicationLauncher.Instance.AddModApplication(
+						ExShipInfo.ToggleGUI, ExShipInfo.ToggleGUI, null, null, null, null,
+						ApplicationLauncher.AppScenes.VAB | ApplicationLauncher.AppScenes.SPH,
+						GameDatabase.Instance.GetTexture("ExtraplanetaryLaunchpads/Textures/icon_button", false)
+					);
+				}
+			}
 		}
 
 		void OnDestroy()
@@ -51,16 +68,32 @@ namespace ExtraplanetaryLaunchpads {
 	public class ExToolbar_BuildWindow : MonoBehaviour
 	{
 		private IButton ExBuildWindowButton;
+		private static ApplicationLauncherButton appBuildWindowButton = null;
 
 		public void Awake ()
 		{
 			if (ToolbarManager.Instance == null) {
+				if (appBuildWindowButton == null) {
+					GameEvents.onGUIApplicationLauncherReady.Add(setupAppButton_BuildWindow);
+				}
 				return;
 			}
 			ExBuildWindowButton = ToolbarManager.Instance.add ("ExtraplanetaryLaunchpads", "ExBuildWindowButton");
 			ExBuildWindowButton.TexturePath = "ExtraplanetaryLaunchpads/Textures/icon_button";
 			ExBuildWindowButton.ToolTip = "EL Build Window";
 			ExBuildWindowButton.OnClick += (e) => ExBuildWindow.ToggleGUI ();
+		}
+
+		public void setupAppButton_BuildWindow() {
+			if (appBuildWindowButton == null) {
+				if (ApplicationLauncher.Ready) {
+					appBuildWindowButton = ApplicationLauncher.Instance.AddModApplication(
+						ExBuildWindow.ToggleGUI, ExBuildWindow.ToggleGUI, null, null, null, null,
+						ApplicationLauncher.AppScenes.FLIGHT,
+						GameDatabase.Instance.GetTexture("ExtraplanetaryLaunchpads/Textures/icon_button", false)
+					);
+				}
+			}
 		}
 
 		void OnDestroy()
@@ -75,16 +108,32 @@ namespace ExtraplanetaryLaunchpads {
 	public class ExToolbar_SettingsWindow : MonoBehaviour
 	{
 		private IButton ExSettingsButton;
+		private static ApplicationLauncherButton appSettingsButton;
 
 		public void Awake ()
 		{
 			if (ToolbarManager.Instance == null) {
+				if (appSettingsButton == null) {
+					GameEvents.onGUIApplicationLauncherReady.Add(setupAppButton_SpaceCenter);
+				}
 				return;
 			}
 			ExSettingsButton = ToolbarManager.Instance.add ("ExtraplanetaryLaunchpads", "ExSettingsButton");
 			ExSettingsButton.TexturePath = "ExtraplanetaryLaunchpads/Textures/icon_button";
 			ExSettingsButton.ToolTip = "EL Settings Window";
 			ExSettingsButton.OnClick += (e) => ExSettings.ToggleGUI ();
+		}
+
+		public void setupAppButton_SpaceCenter() {
+			if (appSettingsButton == null) {
+				if (ApplicationLauncher.Ready) {
+					appSettingsButton = ApplicationLauncher.Instance.AddModApplication(
+						ExSettings.ToggleGUI, ExSettings.ToggleGUI, null, null, null, null,
+						ApplicationLauncher.AppScenes.SPACECENTER,
+						GameDatabase.Instance.GetTexture("ExtraplanetaryLaunchpads/Textures/icon_button", false)
+					);
+				}
+			}
 		}
 
 		void OnDestroy()


### PR DESCRIPTION
If Blizzy's toolbar is not installed, create a stock toolbar icon.

Verified that repeatedly entering a scene (SpaceCenter -> VAB -> SpaceCenter -> VAB) does not create duplicate icons.

<img width="161" alt="space center" src="https://cloud.githubusercontent.com/assets/5103358/16908826/146103bc-4cd7-11e6-810f-306c94a1bf38.png">
<img width="292" alt="vab" src="https://cloud.githubusercontent.com/assets/5103358/16908828/18bb6d08-4cd7-11e6-9b74-c7a19a81cda0.png">
<img width="69" alt="flight" src="https://cloud.githubusercontent.com/assets/5103358/16908827/16122e52-4cd7-11e6-942a-ceb06909584d.png">