### PR TITLE
Adding 3.75m canisters

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeMTL/part.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeMTL/part.cfg
@@ -1,0 +1,61 @@
+PART
+{
+// Kerbal Space Program - Part Config
+// FL-T500 Fuel Tank
+// 
+
+// --- general parameters ---
+name = ELTankXLargeMTL
+module = Part
+author = Aeon-Phoenix
+
+// --- asset parameters ---
+	MODEL {
+		model = ExtraplanetaryLaunchpads/Parts/aeon/ELTankMedMTL/model
+		texture = model00, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model00
+		texture = model01, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model01
+		position	=	0.0, 0.0, 0.0
+		rotation	=	0.0, 0.0, 0.0
+		scale		=	3.0, 3.0, 3.0
+	}
+rescaleFactor = 1.25
+
+
+// --- node definitions ---
+node_stack_top = 0.0, 3.048, 0.0, 0.0, 1.0, 0.0, 3
+node_stack_bottom = 0.0, -3.048, 0.0, 0.0, -1.0, 0.0, 3
+node_attach = 1.515, 0.0, 0.0, 1.0, 0.0, 0.0, 3
+
+
+// --- editor parameters ---
+TechRequired = advRocketry
+entryCost = 4800
+cost = 29551.7
+category = Utility
+subcategory = 0
+title = MSV-4000 Metal Container
+manufacturer = EXLP LLC 
+description = The largest version of the family of containers filled with refined metal. Good to store it, rather inefficient to launch, but possible.
+
+// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+attachRules = 1,1,1,1,0
+
+// --- standard part parameters ---
+mass = 29.05
+dragModelType = default
+maximum_drag = 0.2
+minimum_drag = 0.3
+angularDrag = 2
+crashTolerance = 6
+breakingForce = 50
+breakingTorque = 50
+maxTemp = 2900
+
+RESOURCE
+{
+ name = Metal
+ amount = 0
+ maxAmount = 22604.8
+}
+
+}

--- a/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeORE/part.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeORE/part.cfg
@@ -5,14 +5,14 @@ PART
 // 
 
 // --- general parameters ---
-name = ELTankXLargeMTL
+name = ELTankXLargeORE
 module = Part
 author = Aeon-Phoenix
 
 // --- asset parameters ---
 	MODEL {
 		model = ExtraplanetaryLaunchpads/Parts/aeon/ELTankMedMTL/model
-		texture = model00, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model00
+		texture = model00, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeORE/model00
 		texture = model01, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model01
 		position	=	0.0, 0.0, 0.0
 		rotation	=	0.0, 0.0, 0.0
@@ -30,12 +30,12 @@ node_attach = 1.515, 0.0, 0.0, 1.0, 0.0, 0.0, 3
 // --- editor parameters ---
 TechRequired = advRocketry
 entryCost = 4800
-cost = 233458.4
+cost = 49149.14
 category = Utility
 subcategory = 0
-title = MSV-4000 Metal Container
+title = MSV-4000 Metal Ore Container
 manufacturer = EXLP LLC 
-description = The largest version of the family of containers filled with refined metal. Good to store it, rather inefficient to launch, but possible.
+description = The largest version of the family of containers filled with ore. Good to store it, rather inefficient to launch, but possible.
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
@@ -53,7 +53,7 @@ maxTemp = 2900
 
 RESOURCE
 {
- name = Metal
+ name = MetalOre
  amount = 0
  maxAmount = 22604.8
 }

--- a/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeRP/part.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Parts/aeon/ELTankXLargeRP/part.cfg
@@ -5,14 +5,14 @@ PART
 // 
 
 // --- general parameters ---
-name = ELTankXLargeMTL
+name = ELTankXLargeRP
 module = Part
 author = Aeon-Phoenix
 
 // --- asset parameters ---
 	MODEL {
 		model = ExtraplanetaryLaunchpads/Parts/aeon/ELTankMedMTL/model
-		texture = model00, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model00
+		texture = model00, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeRP/model00
 		texture = model01, ExtraplanetaryLaunchpads/Parts/aeon/ELTankLargeMTL/model01
 		position	=	0.0, 0.0, 0.0
 		rotation	=	0.0, 0.0, 0.0
@@ -30,12 +30,12 @@ node_attach = 1.515, 0.0, 0.0, 1.0, 0.0, 0.0, 3
 // --- editor parameters ---
 TechRequired = advRocketry
 entryCost = 4800
-cost = 233458.4
+cost = 59103.39
 category = Utility
 subcategory = 0
-title = MSV-4000 Metal Container
+title = MSV-4000 Rocketparts Container
 manufacturer = EXLP LLC 
-description = The largest version of the family of containers filled with refined metal. Good to store it, rather inefficient to launch, but possible.
+description = The largest version of the family of containers filled with refined metal. Good to store or to send rocketparts into Orbit
 
 // attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 attachRules = 1,1,1,1,0
@@ -53,7 +53,7 @@ maxTemp = 2900
 
 RESOURCE
 {
- name = Metal
+ name = RocketParts
  amount = 0
  maxAmount = 22604.8
 }


### PR DESCRIPTION
I've been using this mod as part of an upcoming mission. I'm trying to assemble a manned interstellar spacecraft using the Daedalus engine from the Interstellar Extended mod. I'll need 18 kT of metal to assemble the interstellar vehicle. The only way I can reasonably get this craft to orbit without cheats is by using this mod. 

So far the mod is working great! My latest [miner](http://i.imgur.com/wdY3w1R.png) was just recently assembled in orbit. Fully loaded, it should carry 10kT. That's enough to assemble the interstellar vehicle in two shipments. However, it's really pushing the limits on the physics engine. The craft lands on Minimus just fine, but as soon as I fill it up with metal, the Kraken tears it apart as soon as physics easing occurs. 

I really need to keep part count down, so 3.75m canisters are a necessity. I've created some 3.75m canisters on my own. I have tested the 3.75m metal canisters on an updated version of my miner, [shown here](http://i.imgur.com/hXKddlC.png). There are still changes I need to make to the vehicle, but the Kraken attacks are most definitely over.

I'll make whatever edits are needed to get this pull request accepted. I would like to eventually post the mission summary online with craft files, but that won't be possible if I used a tweaked version of the mod. Please let me know if 3.75m parts will never be added for design reasons. I don't see this being an issue with game balance because the user still needs to mine the metal and haul it to orbit, but if so I'll need to drastically adjust my mission profile. 