### PR TITLE
tweakscale configs

### DIFF
--- a/GameData/ExtraplanetaryLaunchpads/Patches/TweakscaleConfigs.cfg
+++ b/GameData/ExtraplanetaryLaunchpads/Patches/TweakscaleConfigs.cfg
@@ -1,0 +1,144 @@
+
+@PART[HexCanMetalHuge]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[HexCanMetalSmall]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}
+
+@PART[HexCanOreHuge]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[HexCanOreSmall]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}
+
+@PART[HexCanRocketPartsHuge]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[HexCanRocketPartsSmall]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}
+
+@PART[ELTankXLargeMTL]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[ELTankSmlMTL]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}
+
+@PART[ELTankXLargeORE]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[ELTankSmlORE]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}
+
+@PART[ELTankXLargeRP]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 3.75
+		type = stack
+		scaleFactors = 3.75, 5, 7.5, 10, 15, 20
+		scaleNames = 3.75m, 5m, 7.5m, 10m, 15m, 20m
+	}
+}
+
+@PART[ELTankSmlRP]
+{
+	MODULE
+	{
+		name = TweakScale
+		defaultScale = 0.625
+		type = stack
+		scaleFactors = 0.15, 0.3, 0.625
+		scaleNames = 0.15m, 0.3m, 0.625m
+	}
+}


### PR DESCRIPTION
This allows the largest and smallest of canisters to be adjusted by tweakscale. 

As I understand it, users can continue using the mod without installing tweakscale, and it will behave just as it was. The tweakscale functionality only comes into play once the user installs tweakscale alongside it. 

Caveat: I've only tested this on my own instance of KSP, so I haven't confirmed the above statements, but I would be surprised if it wasn't the case.