### PR TITLE
KSP 1.10 support, kOS compatibility adjustment, EL build window GUI recovery

### DIFF
--- a/Source/BuildControl.cs
+++ b/Source/BuildControl.cs
@@ -1042,8 +1042,17 @@ namespace ExtraplanetaryLaunchpads {
 			craftVessel.vesselName = "EL craftVessel - " + craft.GetValue ("ship");
 			craftVessel.Initialize (true);
 			foreach (Part part in craftVessel.parts) {
-				part.ModulesOnStart ();
+				// Remove module that triggers OrbitDriver and cause temporary vessel being despawned due to illegal orbit parameters
+				if (part.Modules.Contains("kOSProcessor")) {
+					var kos = part.Modules["kOSProcessor"];
+					if (kos != null) {
+						part.Modules.Remove(kos);
+					}
+				}
+
+				part.ModulesOnStart();
 			}
+
 			if (ELSettings.B9Wings_Present) {
 				if (!InitializeB9Wings (craftVessel)
 					&& ELSettings.FAR_Present) {

--- a/Source/BuildControl.cs
+++ b/Source/BuildControl.cs
@@ -718,16 +718,22 @@ namespace ExtraplanetaryLaunchpads {
 				Debug.LogWarning ($"File '{filename}' does not exist");
 				return;
 			}
-			string craftText = File.ReadAllText (filename);
-			ConfigNode craft = ConfigNode.Parse (craftText);
-			ReplaceLaunchClamps (craft);
 
-			state = State.Planning;
-			craftName = Localizer.Format (craft.GetValue ("ship"));
-			if ((buildCost = getBuildCost (craft, craftText)) != null) {
-				craftConfig = craft;
+			try {
+				string craftText = File.ReadAllText(filename);
+				ConfigNode craft = ConfigNode.Parse(craftText);
+				ReplaceLaunchClamps(craft);
+
+				state = State.Planning;
+				craftName = Localizer.Format(craft.GetValue("ship"));
+				if ((buildCost = getBuildCost(craft, craftText)) != null) {
+					craftConfig = craft;
+				}
+				PlaceCraftHull();
+			} catch (Exception e) {
+				Debug.LogException(e);
+				state = State.Idle;
 			}
-			PlaceCraftHull ();
 		}
 
 		public void UnloadCraft ()

--- a/Source/GUI/BuildWindow.cs
+++ b/Source/GUI/BuildWindow.cs
@@ -809,9 +809,10 @@ namespace ExtraplanetaryLaunchpads {
 		private void craftSelectComplete (string filename,
 										  CraftBrowserDialog.LoadType lt)
 		{
-			control.LoadCraft (filename, flagURL);
 			control.craftType = craftlist.craftType;
 			craftlist = null;
+
+			control.LoadCraft(filename, flagURL);
 		}
 
 		private void craftSelectCancel ()

--- a/Source/GUI/CraftBrowser.cs
+++ b/Source/GUI/CraftBrowser.cs
@@ -158,6 +158,11 @@ namespace ExtraplanetaryLaunchpads {
 			cb.showMergeOption = showMergeOption;
 			cb.OnBrowseCancelled = onCancel;
 			cb.OnFileSelected = onFileSelected;
+			cb.OnConfigNodeSelected =
+				delegate (ConfigNode n, LoadType t) {
+					Debug.Log($"[CraftBrowserDialog] OnConfigNodeSelected - " + cb.selectedEntry.fullFilePath);
+					onFileSelected(cb.selectedEntry.fullFilePath, t);
+				};
 			cb.title = "Select a craft to load";
 			cb.profile = profile;
 

--- a/Source/GUI/CraftBrowser.cs
+++ b/Source/GUI/CraftBrowser.cs
@@ -157,7 +157,6 @@ namespace ExtraplanetaryLaunchpads {
 			cb.facility = craftFacility[(int) type];
 			cb.showMergeOption = showMergeOption;
 			cb.OnBrowseCancelled = onCancel;
-			cb.OnFileSelected = onFileSelected;
 			cb.OnConfigNodeSelected =
 				delegate (ConfigNode n, LoadType t) {
 					Debug.Log($"[CraftBrowserDialog] OnConfigNodeSelected - " + cb.selectedEntry.fullFilePath);


### PR DESCRIPTION
This pull request contains 3 adjustments, one per commit.

1) OnConfigNodeSelected callback for the compatibility with KSP 1.10. I only tested it on 1.10 and I'm not sure at all how this will work in KSP 1.9.x.

2) I found that if something wrong (exception) happens during Craft loading and parsing (inside LoadCraft) the GUI ends up being in State.Planning without other things properly set up. This leads to the window becoming unusable, player cannot even close it. The try-catch with state reverting should allow the mod to recover from at least some kinds of exceptions during the load.

3) kOS compatibility fix. Added the check to remove kOS modules during "virtual spawn" inside getBuildCost method. kOSProcessor module triggers OrbitDriver and cause "virtual vessel" despawn before cost is calculated. No actual dependency from kOS was introduced, of course.